### PR TITLE
fix for 404 sites initially not 404 because of fallback true. Using f…

### DIFF
--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -120,6 +120,6 @@ export async function getStaticPaths() {
 
   return {
     paths: newPaths,
-    fallback: true,
+    fallback: "blocking",
   };
 }


### PR DESCRIPTION
…allback: blocking we can send a 404 if the page do not exist.